### PR TITLE
CYTHINF-150 Options Pattern

### DIFF
--- a/src/Mutedac.Core/LambdaConfiguration.cs
+++ b/src/Mutedac.Core/LambdaConfiguration.cs
@@ -2,6 +2,8 @@ namespace Mutedac
 {
     public class LambdaConfiguration
     {
+        public const string SectionName = "Lambda";
+
         public string WaitForDatabaseAvailabilityRuleName { get; set; } = "";
         public string NotificationQueueUrl { get; set; } = "";
         public string DequeueEventSourceUUID { get; set; } = "";

--- a/src/Mutedac.NotifyDatabaseAvailability/NotifyDatabaseAvailabilityHandler.cs
+++ b/src/Mutedac.NotifyDatabaseAvailability/NotifyDatabaseAvailabilityHandler.cs
@@ -15,6 +15,7 @@ using Lambdajection.Attributes;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using static System.Text.Json.JsonSerializer;
 
@@ -32,12 +33,12 @@ namespace Mutedac.NotifyDatabaseAvailability
         public NotifyDatabaseAvailabilityHandler(
             IAmazonSimpleNotificationService snsClient,
             ILogger<NotifyDatabaseAvailabilityHandler> logger,
-            IConfiguration configuration
+            IOptions<LambdaConfiguration> configuration
         )
         {
             this.snsClient = snsClient;
             this.logger = logger;
-            this.configuration = configuration.GetSection("Lambda").Get<LambdaConfiguration>();
+            this.configuration = configuration.Value;
         }
 
         public async Task<NotifyDatabaseAvailabilityResponse> Handle(SQSEvent request, ILambdaContext context = default!)

--- a/src/Mutedac.NotifyDatabaseAvailability/Startup.cs
+++ b/src/Mutedac.NotifyDatabaseAvailability/Startup.cs
@@ -17,6 +17,7 @@ namespace Mutedac.NotifyDatabaseAvailability
         {
             services.AddScoped<IAmazonSimpleNotificationService, AmazonSimpleNotificationServiceClient>();
             services.AddLogging(options => options.AddConsole());
+            services.Configure<LambdaConfiguration>(Configuration.GetSection(LambdaConfiguration.SectionName));
         }
     }
 }

--- a/src/Mutedac.StartDatabase/Startup.cs
+++ b/src/Mutedac.StartDatabase/Startup.cs
@@ -24,6 +24,7 @@ namespace Mutedac.StartDatabase
             services.AddScoped<IAmazonSQS, AmazonSQSClient>();
             services.AddScoped<IAmazonLambda, AmazonLambdaClient>();
             services.AddLogging(options => options.AddConsole());
+            services.Configure<LambdaConfiguration>(Configuration.GetSection(LambdaConfiguration.SectionName));
         }
     }
 }

--- a/src/Mutedac.StartDatabaseTaskCompleter/StartDatabaseTaskCompleter.cs
+++ b/src/Mutedac.StartDatabaseTaskCompleter/StartDatabaseTaskCompleter.cs
@@ -41,7 +41,11 @@ namespace Mutedac.StartDatabaseTaskCompleter
         {
             var tasks = request.Records.Select(record => CompleteTask(record.Sns));
             await Task.WhenAll(tasks);
-            return await Task.FromResult(new StartDatabaseTaskCompleterResponse { });
+
+            return new StartDatabaseTaskCompleterResponse
+            {
+                Message = "Notified all pending tasks"
+            };
         }
 
         public async Task CompleteTask(SNSEvent.SNSMessage message)

--- a/src/Mutedac.WaitForDatabaseAvailability/Startup.cs
+++ b/src/Mutedac.WaitForDatabaseAvailability/Startup.cs
@@ -20,6 +20,7 @@ namespace Mutedac.WaitForDatabaseAvailability
             services.AddScoped<IAmazonEventBridge, AmazonEventBridgeClient>();
             services.AddScoped<IAmazonLambda, AmazonLambdaClient>();
             services.AddLogging(options => options.AddConsole());
+            services.Configure<LambdaConfiguration>(Configuration.GetSection(LambdaConfiguration.SectionName));
         }
     }
 }

--- a/src/Mutedac.WaitForDatabaseAvailability/WaitForDatabaseAvailabilityHandler.cs
+++ b/src/Mutedac.WaitForDatabaseAvailability/WaitForDatabaseAvailabilityHandler.cs
@@ -15,6 +15,7 @@ using Lambdajection.Attributes;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 [assembly: LambdaSerializer(typeof(DefaultLambdaJsonSerializer))]
 
@@ -34,14 +35,14 @@ namespace Mutedac.WaitForDatabaseAvailability
             IAmazonLambda lambdaClient,
             IAmazonEventBridge eventsClient,
             ILogger<WaitForDatabaseAvailabilityHandler> logger,
-            IConfiguration configuration
+            IOptions<LambdaConfiguration> configuration
         )
         {
             this.rdsClient = rdsClient;
             this.lambdaClient = lambdaClient;
             this.eventsClient = eventsClient;
             this.logger = logger;
-            this.configuration = configuration.GetSection("Lambda").Get<LambdaConfiguration>();
+            this.configuration = configuration.Value;
         }
 
         public async Task<WaitForDatabaseAvailabilityResponse> Handle(WaitForDatabaseAvailabilityRequest request, ILambdaContext context = default!)

--- a/tests/NotifyDatabaseAvailabilityTests.cs
+++ b/tests/NotifyDatabaseAvailabilityTests.cs
@@ -17,6 +17,7 @@ using Amazon.SQS.Model;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using NSubstitute;
 
@@ -46,12 +47,11 @@ namespace Mutedac.NotifyDatabaseAvailability
             public override Task Setup()
             {
                 var logger = Substitute.For<ILogger<NotifyDatabaseAvailabilityHandler>>();
-                var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
+                var configuration = new OptionsWrapper<LambdaConfiguration>(new LambdaConfiguration
                 {
-                    ["Lambda:NotificationQueueUrl"] = queueUrl,
-                    ["Lambda:DequeueEventSourceUUID"] = dequeueEventSourceUuid,
-                }).Build();
+                    NotificationQueueUrl = queueUrl,
+                    DequeueEventSourceUUID = dequeueEventSourceUuid
+                });
 
                 StartDatabaseHandler = new NotifyDatabaseAvailabilityHandler(SnsClient, logger, configuration);
                 return Task.CompletedTask;

--- a/tests/WaitForDatabaseAvailabilityTests.cs
+++ b/tests/WaitForDatabaseAvailabilityTests.cs
@@ -14,6 +14,7 @@ using Amazon.SQS.Model;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using NSubstitute;
 
@@ -45,13 +46,12 @@ namespace Mutedac.WaitForDatabaseAvailability
             public override Task Setup()
             {
                 var logger = Substitute.For<ILogger<WaitForDatabaseAvailabilityHandler>>();
-                var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
+                var configuration = new OptionsWrapper<LambdaConfiguration>(new LambdaConfiguration
                 {
-                    ["Lambda:WaitForDatabaseAvailabilityRuleName"] = waitForDatabaseAvailabilityRuleName,
-                    ["Lambda:NotificationQueueUrl"] = queueUrl,
-                    ["Lambda:DequeueEventSourceUUID"] = dequeueEventSourceUuid,
-                }).Build();
+                    WaitForDatabaseAvailabilityRuleName = waitForDatabaseAvailabilityRuleName,
+                    NotificationQueueUrl = queueUrl,
+                    DequeueEventSourceUUID = dequeueEventSourceUuid,
+                });
 
                 StartDatabaseHandler = new WaitForDatabaseAvailabilityHandler(RdsClient, LambdaClient, EventBridgeClient, logger, configuration);
                 return Task.CompletedTask;


### PR DESCRIPTION
Now using the [options pattern](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-3.1) for loading configuration into the Start Database Lambdas. 

Also, only disables the event source mapping for the notify database availability function if the notification topic was provided. 